### PR TITLE
Feat/bac 66 endpoint to convert currencies

### DIFF
--- a/backend/app/api/v1/api_service.py
+++ b/backend/app/api/v1/api_service.py
@@ -24,8 +24,8 @@ async def get_currency_rates_from_external_apis(db: Session = Depends(get_db)) -
     try:
         all_currencies = db.query(Currency).all()
         for currency in all_currencies:
-            currency_list.append(currency.isocode)
-            currency_code = currency.isocode
+            currency_list.append(currency.isocode.upper())
+            currency_code = currency.isocode.upper()
             resp_data = await get_binancep2p_rate(currency_code)
             formatted_data = await format_binance_response_data(resp_data)
             official_rate = make_official_rate_request(

--- a/backend/app/api/v1/rate.py
+++ b/backend/app/api/v1/rate.py
@@ -1,6 +1,6 @@
 from typing import Any, List
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from app import schemas, crud
@@ -8,6 +8,7 @@ from app.api.deps import get_db
 from app.models.rate import Rate
 from app.models.currency import Currency
 from app.api.deps import get_location
+
 router = APIRouter()
 
 #  get rates ofbject for a spcific isocode
@@ -72,3 +73,58 @@ def get_rate(db: Session = Depends(get_db), skip: int = 0, limit: int = 100) -> 
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
                             detail="rates are not available at the moment")
     return rate
+
+
+@router.get("/convert")
+def convert_currency(
+    *,
+    db: Session = Depends(get_db),
+    from_currency: str = Query(max_length=3, min_length=3),
+    to_currency: str = Query(max_length=3, min_length=3),
+    amount: str,
+) -> Any:
+    """
+    This endpoint converts amount from one currency to another.
+    `amount`: The amount you want to covert
+    `from_currency`: The isocode of currency you want to convert from.
+    `to_currency`: The isocode of currency you want to convert to.
+    """
+    from_currency_in, to_currency_in = from_currency.upper(), to_currency.upper()
+    from_currency_obj = crud.currency.get_currency_by_isocode(
+        db, isocode=from_currency_in
+    )
+    to_currency_obj = crud.currency.get_currency_by_isocode(db, isocode=to_currency_in)
+    if from_currency_obj is None or to_currency_obj is None:
+        return {"success": False, "message": "Please send a valid currency isocode."}
+
+    try:
+        from_rate_obj = crud.rate.get_rate_by_currency_id(
+            db, currency_id=from_currency_obj.id
+        )
+        to_rate_obj = crud.rate.get_rate_by_currency_id(
+            db, currency_id=to_currency_obj.id
+        )
+        from_official_rate, to_official_rate = (
+            from_rate_obj.official_buy,
+            to_rate_obj.official_buy,
+        )
+        from_parallel_rate, to_parallel_rate = (
+            from_rate_obj.parallel_buy,
+            to_rate_obj.parallel_buy,
+        )
+
+        official_result = float(amount) / from_official_rate * to_official_rate
+        parallel_result = float(amount) / from_parallel_rate * to_parallel_rate
+
+        return {
+            "success": True,
+            "data": {
+                "amount": amount,
+                "from": from_currency_in,
+                "to": to_currency_in,
+                "parallel_total": "{:,.2f}".format(parallel_result),
+                "official_total": "{:,.2f}".format(official_result),
+            },
+        }
+    except:
+        return {"success": False, "message": "Failed to convert currencies."}

--- a/backend/app/crud/rate.py
+++ b/backend/app/crud/rate.py
@@ -1,7 +1,7 @@
 from typing import Optional, List
 
 from sqlalchemy.orm import Session
-
+from sqlalchemy import desc
 from app.crud.base import CRUDBase
 from app.models.rate import Rate
 # from app.schemas.currency import Currency as currency_schema
@@ -10,7 +10,17 @@ from app.schemas.rate import RateCreate, RateBase
 
 class CRUDRate(CRUDBase[Rate, RateCreate, RateBase]):
     # Declare model specific CRUD operation methods.
-    pass
+
+    def get_rate_by_currency_id(self, db: Session, currency_id: int) -> Optional[Rate]:
+        """
+        Gets the latest rate of a currency using the currency_id.
+        """
+        return (
+            db.query(Rate)
+            .filter(Rate.currency_id == currency_id)
+            .order_by(desc(Rate.id))
+            .first()
+        )
 
 
 rate = CRUDRate(Rate)

--- a/backend/app/tests/api/v1/test_rate.py
+++ b/backend/app/tests/api/v1/test_rate.py
@@ -1,8 +1,9 @@
-from typing import Dict
+from typing import Any, Dict
 
 from fastapi.testclient import TestClient
 
 from app.core import settings
+from app.tests.conftest import random_currency
 
 
 
@@ -12,3 +13,13 @@ def test_read_currency(client: TestClient) -> None:
     assert response.status_code == 200
     assert type(rates) == dict
 
+
+def test_convert_currency(client: TestClient, random_currency: Dict[str, Any]) -> None:
+    amount = 1000
+    from_currency, to_currency = random_currency["isocode"], random_currency["isocode"]
+    response = client.get(f"{settings.API_V1_STR}/rate/convert?from_currency={from_currency}&to_currency={to_currency}&amount={amount}")
+    data = response.json()
+    assert response.status_code == 200
+    assert data["success"] == True
+    assert data["data"]["amount"] == str(amount)
+    assert data["data"]["official_total"] == "{:,.2f}".format(amount)

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -26,3 +26,13 @@ def random_product() -> Dict[str, str]:
         "name": "Test Product",
         "price": 80,
     }
+
+
+@pytest.fixture(scope="module")
+def random_currency() -> Dict[str, str]:
+    return {
+        "id": 1,
+        "country": "Nigeria",
+        "isocode": "NGN",
+        "sysmbol": "N"
+    }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,10 @@
-﻿aiosmtplib==1.1.7
+aiohttp==3.8.3
+aiosignal==1.3.1
+aiosmtplib==1.1.7
 alembic==1.8.1
 anyio==3.6.2
 async-generator==1.10
+async-timeout==4.0.2
 attrs==22.1.0
 bcrypt==4.0.1
 blinker==1.5
@@ -18,6 +21,7 @@ exceptiongroup==1.0.4
 fastapi==0.87.0
 fastapi-mail==1.1.5
 filelock==3.8.0
+frozenlist==1.3.3
 greenlet==2.0.1
 h11==0.12.0
 httpcore==0.15.0
@@ -29,6 +33,7 @@ iniconfig==1.1.1
 Jinja2==3.1.2
 Mako==1.2.4
 MarkupSafe==2.1.1
+multidict==6.0.2
 outcome==1.2.0
 packaging==21.3
 passlib==1.7.4
@@ -56,10 +61,11 @@ starlette==0.21.0
 tomli==2.0.1
 trio==0.22.0
 trio-websocket==0.9.2
-typing_extensions==4.4.0
+typing-extensions==4.4.0
 urllib3==1.26.12
 uvicorn==0.19.0
 virtualenv==20.16.7
 virtualenv-clone==0.5.7
 wsproto==1.2.0
+yarl==1.8.1
 zipp==3.10.0


### PR DESCRIPTION
Ticket: <a href="https://linear.app/team-bevel/issue/BAC-66/create-an-endpoint-to-convert-between-currencies">BAC-66</a>

- The /rate/convert endpoint gets from_currency, to_currency, amount from the get request
- Checks if currencies exist in the database
- Gets the rate for each of the currencies from the database
- Coverts the currency using the formula (amount/from * to)
- Added unit test

Sample Request: ```GET: /api/rate/convert?from_currency=GHS&to_currency=NGN&amount=1000```
Sample Response:
```
{
  "success": true,
  "data": {
    "amount": "1000",
    "from": "GHS",
    "to": "NGN",
    "parallel_total": "52,248.82",
    "official_total": "30,486.48"
  }
}
```