### PR TITLE
str-37: Create a GET endpoint that returns links to financial news about a country or currency

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -9,6 +9,7 @@ from app.api.v1 import auth
 from app.api.v1 import password_email_reset
 
 from app.api.v1 import api_service
+from app.api.v1 import news
 
 api_router = APIRouter()
 
@@ -22,3 +23,4 @@ api_router.include_router(password_email_reset.router,
                           prefix="/forget_password", tags=["reset_password"])
 api_router.include_router(
     api_service.router, prefix="/service", tags=["services"])
+api_router.include_router(news.router, prefix="/news", tags=["news"])

--- a/backend/app/api/v1/news.py
+++ b/backend/app/api/v1/news.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+from fastapi import APIRouter
+from app.news_util.news_util import get_news_for_user_location as get_news
+
+router = APIRouter()
+
+
+@router.get("/{ip}")
+def get_news_for_user_location(ip):
+	"""Returns the news for a user's location"""
+	response = get_news(ip)
+	if response:
+		return response
+	return {"status": "failure"}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from app.api.v1 import api_router
 from app.core import settings
 from app.api.v1 import password_email_reset
 
-app = FastAPI(title=settings.PROJECT_NAME, root_path="/backend/")
+app = FastAPI(title=settings.PROJECT_NAME) #, root_path="/backend/")
 origins = [
     "http://localhost",
     "http://localhost:3000",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from app.api.v1 import api_router
 from app.core import settings
 from app.api.v1 import password_email_reset
 
-app = FastAPI(title=settings.PROJECT_NAME) #, root_path="/backend/")
+app = FastAPI(title=settings.PROJECT_NAME, root_path="/backend/")
 origins = [
     "http://localhost",
     "http://localhost:3000",

--- a/backend/app/news_util/news_util.py
+++ b/backend/app/news_util/news_util.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Defines function to scrape news data from the web
+"""
+from app.api.deps import get_location
+from os import environ
+import requests
+
+api_key = environ.get('NEWS_API_KEY')
+
+countries = {
+	"Argentina": "ar",
+	"Australia": "au",
+	"Austria": "at",
+	"Azerbaijan": "az",
+	"Bangladesh": "bd",
+	"Belarus": "by",
+	"Belgium": "be",
+	"Bolivia": "bo",
+	"Brazil": "br",
+	"Bulgaria": "bg",
+	"Cameroon": "cm",
+	"Canada": "ca",
+	"Chile": "cl",
+	"China": "cn",
+	"Colombia": "co",
+	"Costa Rica": "cr",
+	"Cuba": "cu",
+	"Czech republic": "cz",
+	"Denmark": "dk",
+	"Dominican Republic": "do",
+	"Ecuador": "ec",
+	"Egypt": "eg",
+	"Estonia": "ee",
+	"Ethiopia": "et",
+	"Finland": "fi",
+	"France": "fr",
+	"Germany": "de",
+	"Ghana": "gh",
+	"Greece": "gr",
+	"Hong Kong": "hk",
+	"Hungary": "hu",
+	"India": "in",
+	"Indonesia": "id",
+	"Iraq": "iq",
+	"Ireland ":"ie",
+	"Israel": "il",
+	"Italy": "it",
+	"Japan": "jp",
+	"Jordan": "jo",
+	"Kazakhstan": "kz",
+	"Kuwait": "kw",
+	"Latvia": "lv",
+	"Lebanon": "lb",
+	"Lithuania": "lt",
+	"Madagascar": "mg",
+	"Malaysia": "my",
+	"Mexico": "mx",
+	"Morocco": "ma",
+	"Mozambique": "mz",
+	"Myanmar": "mm",
+	"Netherland": "nl",
+	"New zealand": "nz",
+	"Nigeria": "ng",
+	"North Korea": "kp",
+	"Norway": "no",
+	"Pakistan": "pk",
+	"Paraguay": "py",
+	"Peru": "pe",
+	"Philippines": "ph",
+	"Poland": "pl",
+	"Portugal": "pt",
+	"Puerto Rico": "pr",
+	"Romania": "ro",
+	"Russia": "ru",
+	"Saudi Arabia": "sa",
+	"Serbia": "rs",
+	"Singapore": "sg",
+	"Slovakia": "sk",
+	"Slovenia": "si",
+	"South Africa": "za",
+	"South Korea": "kr",
+	"Spain": "es",
+	"Sudan": "sd",
+	"Sweden": "se",
+	"Switzerland": "ch",
+	"Taiwan": "tw",
+	"Tanzania": "tz",
+	"Thailand": "th",
+	"Turkey": "tr",
+	"Ukraine": "ua",
+	"United Arab Emirates": "ae",
+	"United Kingdom": "gb",
+	"United States": "us",
+	"Venezuela": "ve",
+	"Vietnam": "vi",
+}
+
+def get_news_for_user_location(ip):
+	# Get location of IP
+	country = get_location(ip)
+	# Get country code
+	code = countries.get(country, "us,ng,uk")
+	news_url = f"https://newsdata.io/api/1/news?apikey={api_key}&country={code}&category=business&&q=currency%20OR%20finance"
+
+	# Query API
+	response = requests.get(news_url)
+
+	if response.status_code == 200:
+		if response.json().get("totalResults") == 0:
+			news_url = f"https://newsdata.io/api/1/news?apikey={api_key}&country=us,ng,uk&category=business&&q=currency%20OR%20finance"
+
+			# Query API
+			response = requests.get(news_url)
+			return response.json()
+		return response.json()
+	else:
+		return None
+

--- a/backend/example.env
+++ b/backend/example.env
@@ -2,7 +2,7 @@ ADMIN_USER_NAME= "ibukun46@gmail.com"
 ADMIN_PASSWORD= "secret"
 ALGORITHM= "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES= 30
-SQLALCHEMY_DATABASE_URI="sqlite:///./realexchange_db.db"
+SQLALCHEMY_DATABASE_URI="sqlite:///./realexchangerate.db"
 
 MAIL_USERNAME=from_'Mmachi Ejibe'
 MAIL_PASSWORD='!@12qwAS'
@@ -11,3 +11,5 @@ MAIL_PORT=587
 MAIL_SERVER='smtp.gmail.com'
 MAIL_TLS=True
 MAIL_SSL=False
+
+NEWS_API_KEY="pub_1398939f0f7b50edc135fe97e312142408aaa"


### PR DESCRIPTION
A GET endpoint that returns relevant financial news to users depending on their location.
It takes an IP address, validates the IP address, Gets the country of the IP address and then returns news for the user's country.

example:
    ```https://exchange.hng.tech/api/news/102.44.466.825```

result:
    ```
    {
  "status": "success",
  "totalResults": 1,
  "results": [
    {
      "title": "Stanbic IBTC Upgrades Short-term Loan Solution In Healthcare",
      "link": "https://leadership.ng/stanbic-ibtc-upgrades-short-term-loan-solution-in-healthcare/",
      "keywords": [
        "Business"
      ],
      "creator": [
        ".."
      ],
      "video_url": null,
      "description": "The growth of the Nigerian healthcare sector rests on impactful and innovative finance solutions positioned to create a level playing field for businesses to thrive, even as Stanbic IBTC, a subsidiary of Stanbic IBTC Holdings, has upgraded its short-term loan solution within the healthcare value chain, as effort to improve the sector. This upgrade ensures […]",
      "content": null,
      "pubDate": "2022-11-28 15:30:22",
      "image_url": null,
      "source_id": "leadership",
      "country": [
        "nigeria"
      ],
      "category": [
        "business"
      ],
      "language": "english"
    }
  ],
  "nextPage": null
}
    ```