### PR TITLE
Style(STR-17): fixes terms alignment and spacing

### DIFF
--- a/frontend/client/src/Pages/TermsAndConditions/TermsAndConditions.jsx
+++ b/frontend/client/src/Pages/TermsAndConditions/TermsAndConditions.jsx
@@ -1,164 +1,189 @@
-import { Container, useTheme } from "@mui/material";
+import { Container, Box, useTheme } from "@mui/material";
 import { PageTitle } from "./components/PageTitle.styled";
 import { TermsWrapper } from "./styles/TermsWrapper.styled";
 
 const TermsAndConditions = () => {
-  const theme = useTheme()
-	const DarkMode = theme.palette.mode === 'dark'
+  const theme = useTheme();
+  const DarkMode = theme.palette.mode === "dark";
 
-	const textColor = DarkMode ? "#fff" : ""
+  const textColor = DarkMode ? "#fff" : "";
   return (
-    <Container>
-      <PageTitle style={{color:textColor}}>Terms of Use and Liability Disclaimers</PageTitle>
+    <Box
+      sx={{
+        maxWidth: { xs: "90%", lg: "84%" },
+        marginInline: "auto",
+      }}
+    >
+      <div style={{ marginBlockEnd: "60px" }}>
+        <PageTitle style={{ color: textColor }}>
+          Terms of Use and Liability Disclaimers
+        </PageTitle>
 
-      <TermsWrapper>
-        <h2 style={{color:textColor}}>Terms of Use</h2>
-        <p>
-          This website is provided by the Street Rate company as a service to
-          its users. Users are defined for the puroses of this statement as
-          “You”. Your access to, and use of, this website constitutes your
-          agreement to accept theses Terms of Use and Disclaimers
-        </p>
-        <p>
-          If you do not agree with these Terms of Use, or any part of them, you
-          may leave the website
-        </p>
-        <p>
-          Street Rate reserves the right to update or modify these Terms of Use
-          and Disclaimers without prior notice. You continued use of this
-          website followwing any changes constitutes your agreement to accept
-          such changes
-        </p>
+        <TermsWrapper>
+          <h2 style={{ color: textColor }}>Terms of Use</h2>
+          <p>
+            This website is provided by the Street Rate company as a service to
+            its users. Users are defined for the puroses of this statement as
+            “You”. Your access to, and use of, this website constitutes your
+            agreement to accept theses Terms of Use and Disclaimers
+          </p>
+          <p>
+            If you do not agree with these Terms of Use, or any part of them,
+            you may leave the website
+          </p>
+          <p>
+            Street Rate reserves the right to update or modify these Terms of
+            Use and Disclaimers without prior notice. You continued use of this
+            website followwing any changes constitutes your agreement to accept
+            such changes
+          </p>
 
-        <h4 style={{color:textColor}}>1. Copyright / Permission to Reproduce</h4>
-        <p>
-          Content on this website is produced and/or compiled by Street Rates
-          for the purpose of providing users with information related to the
-          activities of the currency market. Street Rates permits you to freely
-          use, copy, distribute and transmit its website content under the
-          following terms:
-        </p>
+          <h4 style={{ color: textColor, marginBlock: "30px 0px" }}>
+            1. Copyright / Permission to Reproduce
+          </h4>
+          <p>
+            Content on this website is produced and/or compiled by Street Rates
+            for the purpose of providing users with information related to the
+            activities of the currency market. Street Rates permits you to
+            freely use, copy, distribute and transmit its website content under
+            the following terms:
+          </p>
 
-        <h4 style={{color:textColor}}>1.1. Attribution</h4>
-        <p>
-          Content on this website is produced and/or compiled by Street Rates
-          for the purpose of providing users with information related to the
-          activities of the currency market. Street Rates permits you to freely
-          use, copy, distribute and transmit its website content under the
-          following terms:
-        </p>
+          <h5 style={{ color: textColor }}>1.1. Attribution</h5>
+          <p>
+            Content on this website is produced and/or compiled by Street Rates
+            for the purpose of providing users with information related to the
+            activities of the currency market. Street Rates permits you to
+            freely use, copy, distribute and transmit its website content under
+            the following terms:
+          </p>
 
-        <h4 style={{color:textColor}}>1.2. Use of Content: Notice Requirement</h4>
-        <p>
-          If You provide content from this website through paid services or
-          incorporate any content in documents for sale (regardless of the
-          medium), you must inform any prospective purchaser, prior to its
-          distribution or sale, that said content was obtained from this website
-          and that such information is available on this website free of charge.
-        </p>
+          <h5 style={{ color: textColor }}>
+            1.2. Use of Content: Notice Requirement
+          </h5>
+          <p>
+            If You provide content from this website through paid services or
+            incorporate any content in documents for sale (regardless of the
+            medium), you must inform any prospective purchaser, prior to its
+            distribution or sale, that said content was obtained from this
+            website and that such information is available on this website free
+            of charge.
+          </p>
 
-        <h4 style={{color:textColor}}>2. Third Parties</h4>
+          <h4 style={{ color: textColor, marginBlock: "30px 0px" }}>
+            2. Third Parties
+          </h4>
 
-        <h4 style={{color:textColor}}>2.1. Third Party Advertisements</h4>
-        <p>
-          Any dealings with third parties (including advertisers) included
-          within the Website and/or participation in promotions, including the
-          delivery of and the payment for goods and services, and any other
-          terms, conditions, warranties or representations associated with such
-          dealings or promotions are solely between you and the advertiser or
-          other third party. Street Rates shall not be responsible or liable for
-          any part of any such dealings or promotions.
-        </p>
+          <h5 style={{ color: textColor }}>2.1. Third Party Advertisements</h5>
+          <p>
+            Any dealings with third parties (including advertisers) included
+            within the Website and/or participation in promotions, including the
+            delivery of and the payment for goods and services, and any other
+            terms, conditions, warranties or representations associated with
+            such dealings or promotions are solely between you and the
+            advertiser or other third party. Street Rates shall not be
+            responsible or liable for any part of any such dealings or
+            promotions.
+          </p>
 
-        <h4 style={{color:textColor}}>2.2. Links</h4>
-        <p>
-          The Website may contain links to websites controlled or offered by
-          third parties (non-affiliates of Street Rates). Street Rates disclaims
-          liability for any information, materials, products or services posted
-          or offered at any such linked sites. You are responsible for viewing
-          and abiding by the privacy statements and terms of use posted at such
-          linked site. If you provide a link to Street Rate’s website on your
-          website, you shall not indicate or suggest that Street Rates is
-          affiliated with, endorses or sponsors your website or any non-Street
-          Rate web site, entity, service or product and shall not use any Street
-          Rate trademarks without the express prior written permission of Street
-          Rate.
-        </p>
+          <h5 style={{ color: textColor }}>2.2. Links</h5>
+          <p>
+            The Website may contain links to websites controlled or offered by
+            third parties (non-affiliates of Street Rates). Street Rates
+            disclaims liability for any information, materials, products or
+            services posted or offered at any such linked sites. You are
+            responsible for viewing and abiding by the privacy statements and
+            terms of use posted at such linked site. If you provide a link to
+            Street Rate’s website on your website, you shall not indicate or
+            suggest that Street Rates is affiliated with, endorses or sponsors
+            your website or any non-Street Rate web site, entity, service or
+            product and shall not use any Street Rate trademarks without the
+            express prior written permission of Street Rate.
+          </p>
 
-        <h4 style={{color:textColor}}>3. Non-Investment Advice</h4>
-        <p>
-          Street Rate does not endorse or recommend any particular securities,
-          currencies, or other financial products. The content published on the
-          website is solely for informational purposes and is not to be
-          construed as solicitation or any offer to buy or sell any spot
-          currency transactions, financial instruments or other securities.
-          Street Rates does not represent or guarantee that any content on the
-          website is accurate, nor that such content is a complete statement or
-          summary of the marketplace. Nothing contained in the website is
-          intended to constitute investment, legal, tax, accounting or other
-          professional advice and you should not rely on the reports, data or
-          other information provided on or accessible through the use of the
-          website for making financial decisions. You should consult with an
-          appropriate professional for specific advice tailored to your
-          situation and/or to verify the accuracy of the information provided
-          herein prior to making any investment decisions.
-        </p>
-      </TermsWrapper>
+          <h4 style={{ color: textColor, marginBlock: "30px 0px" }}>
+            3. Non-Investment Advice
+          </h4>
+          <p>
+            Street Rate does not endorse or recommend any particular securities,
+            currencies, or other financial products. The content published on
+            the website is solely for informational purposes and is not to be
+            construed as solicitation or any offer to buy or sell any spot
+            currency transactions, financial instruments or other securities.
+            Street Rates does not represent or guarantee that any content on the
+            website is accurate, nor that such content is a complete statement
+            or summary of the marketplace. Nothing contained in the website is
+            intended to constitute investment, legal, tax, accounting or other
+            professional advice and you should not rely on the reports, data or
+            other information provided on or accessible through the use of the
+            website for making financial decisions. You should consult with an
+            appropriate professional for specific advice tailored to your
+            situation and/or to verify the accuracy of the information provided
+            herein prior to making any investment decisions.
+          </p>
+        </TermsWrapper>
 
-      <TermsWrapper>
-        <h2 style={{color:textColor}}>Liability Disclaimers</h2>
-        <p>
-          The information on this website is provided for general reference
-          purposes only. While every effort is made to ensure that the site is
-          up to date and accurate, Street Rates accepts no responsibility or
-          liability for the accuracy or completeness of the content or for any
-          loss which may arise from reliance on information contained in this
-          website.
-        </p>
-        <p>
-          You acknowledge that your use of the information and data, including
-          rates and statistics, provided through this website is at your sole
-          and own risk. Under no circumstances shall Street Rates, its
-          employees, directors, officers, agents, vendors or licensors involved
-          in creating, producing or delivering this site or content found on
-          this site be liable for any loss, injury, claim, liability or damage
-          of any kind resulting in any way from: (a) any content or material
-          downloaded from this website; (b) any links provided on this website;
-          (c) any errors in, or omissions from, the data found on this website;
-          (d) the unavailability or delay of any such data; or (e) your use of
-          the data found on this website or any conclusions you draw from it,
-          regardless of whether you received any assistance from Street Rates or
-          its employees with regard to such data.
-        </p>
-        <p>
-          Under no circumstances is Street Rates liable to you for any amount.
-          Street Rates provides no warranty, express or implied, as to the
-          accuracy, timeliness, completeness, merchantability, fitness for any
-          particular purpose, title, quality or non-infringement of any service
-          or information contained on the website in any form or manner
-          whatsoever. Links to other sites are provided for your convenience.
-          Street Rates accepts no responsibility or liability for the content of
-          those sites or of any external site which links to this site.
-        </p>
-        <p>
-          Your use of the website and/or the Tools shall be subject to all
-          applicable laws and regulations. Street Rates may enforce the Terms of
-          Use in the jurisdiction of any Street Rates affiliate. Certain
-          sections or pages of the website may contain separate terms or
-          conditions. In the event of a conflict, these separate terms and
-          conditions (if any) will govern for those sections or pages. You agree
-          that your use of the website will not create any joint venture,
-          partnership, employment or agency relationship between you and Street
-          Rates. If any part of these Terms of Use is determined to be invalid
-          or unenforceable pursuant to applicable law, including but not limited
-          to the warranty disclaimers and liability limitations set forth above,
-          then the invalid or unenforceable provision will be deemed superceded
-          by a valid and enforceable provision that most closely matches the
-          intent of the original provision and the remainder of these Terms of
-          Use shall continue in effect.
-        </p>
-      </TermsWrapper>
-    </Container>
+        {/* style(STR-17): fixes aligment and spacing */}
+
+        <TermsWrapper>
+          <h2 style={{ color: textColor, marginBlock: "60px 20px" }}>
+            Liability Disclaimers
+          </h2>
+          <p>
+            The information on this website is provided for general reference
+            purposes only. While every effort is made to ensure that the site is
+            up to date and accurate, Street Rates accepts no responsibility or
+            liability for the accuracy or completeness of the content or for any
+            loss which may arise from reliance on information contained in this
+            website.
+          </p>
+          <p>
+            You acknowledge that your use of the information and data, including
+            rates and statistics, provided through this website is at your sole
+            and own risk. Under no circumstances shall Street Rates, its
+            employees, directors, officers, agents, vendors or licensors
+            involved in creating, producing or delivering this site or content
+            found on this site be liable for any loss, injury, claim, liability
+            or damage of any kind resulting in any way from: (a) any content or
+            material downloaded from this website; (b) any links provided on
+            this website; (c) any errors in, or omissions from, the data found
+            on this website; (d) the unavailability or delay of any such data;
+            or (e) your use of the data found on this website or any conclusions
+            you draw from it, regardless of whether you received any assistance
+            from Street Rates or its employees with regard to such data.
+          </p>
+          <p>
+            Under no circumstances is Street Rates liable to you for any amount.
+            Street Rates provides no warranty, express or implied, as to the
+            accuracy, timeliness, completeness, merchantability, fitness for any
+            particular purpose, title, quality or non-infringement of any
+            service or information contained on the website in any form or
+            manner whatsoever. Links to other sites are provided for your
+            convenience. Street Rates accepts no responsibility or liability for
+            the content of those sites or of any external site which links to
+            this site.
+          </p>
+          <p>
+            Your use of the website and/or the Tools shall be subject to all
+            applicable laws and regulations. Street Rates may enforce the Terms
+            of Use in the jurisdiction of any Street Rates affiliate. Certain
+            sections or pages of the website may contain separate terms or
+            conditions. In the event of a conflict, these separate terms and
+            conditions (if any) will govern for those sections or pages. You
+            agree that your use of the website will not create any joint
+            venture, partnership, employment or agency relationship between you
+            and Street Rates. If any part of these Terms of Use is determined to
+            be invalid or unenforceable pursuant to applicable law, including
+            but not limited to the warranty disclaimers and liability
+            limitations set forth above, then the invalid or unenforceable
+            provision will be deemed superceded by a valid and enforceable
+            provision that most closely matches the intent of the original
+            provision and the remainder of these Terms of Use shall continue in
+            effect.
+          </p>
+        </TermsWrapper>
+      </div>
+    </Box>
   );
 };
 

--- a/frontend/client/src/Pages/TermsAndConditions/components/PageTitle.styled.jsx
+++ b/frontend/client/src/Pages/TermsAndConditions/components/PageTitle.styled.jsx
@@ -1,13 +1,13 @@
 import styled from "styled-components";
 
-export const PageTitle = styled.h1 `
-    font-size: 48px;
-    letter-spacing: -0.04em;
-    color: #0F172A;
-    font-family: 'inter-bold', sans-serif;
-    margin: 56px 0 0;
+export const PageTitle = styled.h1`
+  font-size: 39px;
+  letter-spacing: -0.04em;
+  color: #0f172a;
+  font-family: "inter-bold", sans-serif;
+  margin: 48px 0 32px;
 
-    @media(max-width: 600px) {
-        font-size: 28px;
-    }
-`
+  @media (max-width: 600px) {
+    font-size: 32px;
+  }
+`;

--- a/frontend/client/src/Pages/TermsAndConditions/styles/TermsWrapper.styled.jsx
+++ b/frontend/client/src/Pages/TermsAndConditions/styles/TermsWrapper.styled.jsx
@@ -1,34 +1,41 @@
 import styled from "styled-components";
 
-export const TermsWrapper = styled.div `
-    margin-top: 44px;
+export const TermsWrapper = styled.div`
+  margin-top: 36px;
 
-    h2 {
-        font-size: 32px;
-        letter-spacing: -0.02em;
-        color: #0F172A;
-        font-family: 'inter-bold', sans-serif;
-        margin-bottom: 24px;
+  h2 {
+    font-size: 28px;
+    letter-spacing: -0.02em;
+    color: #0f172a;
+    font-family: "inter-bold", sans-serif;
+    /* margin-bottom: 24px; */
 
-        @media(max-width: 600px) {
-            font-size: 24px;
-        }
+    @media (max-width: 600px) {
+      font-size: 22px;
     }
-    h4 {
-        font-size: 20px;
-        line-height: 28px;
-        color: #0F172A;
-        font-family: 'inter-smbold', sans-serif;
-        margin: 18px 0 24px;
-    }
-    p {
-        font-size: 18px;
-        line-height: 24px;
-        color: #555962;
-        margin: 16px 0;
+  }
+  h4 {
+    font-size: 20px;
+    line-height: 28px;
+    color: #0f172a;
+    font-family: "inter-smbold", sans-serif;
+    margin: 18px 0 24px;
+  }
+  h5 {
+    font-size: 18px;
+    line-height: 24px;
+    color: #0f172a;
+    font-family: "inter-smbold", sans-serif;
+    margin-block: 12px 6px;
+  }
+  p {
+    font-size: 16px;
+    line-height: 24px;
+    color: #555962;
+    margin: 8px 0;
 
-        @media(max-width: 600px) {
-            font-size: 16px;
-        }
-    }
-`
+    /* @media (max-width: 600px) {
+      font-size: 16px;
+    } */
+  }
+`;


### PR DESCRIPTION
# STR-17(https://linear.app/team-bevel/issue/STR-17/fix-alignment-and-spacing-for-terms-and-condition-page)

# Before1
![terms_page](https://user-images.githubusercontent.com/97756376/204667607-b9475bba-5860-4d11-be14-9458f3547753.png)

# Before2
![terms_page2](https://user-images.githubusercontent.com/97756376/204667655-2749a26c-fad3-4e1a-9cfb-e51d678ce361.png)

# After1
![termsAfter](https://user-images.githubusercontent.com/97756376/204667739-cbe2bee2-901e-428d-a210-65c98e42ee64.png)

# After2
![termsAfter2](https://user-images.githubusercontent.com/97756376/204667781-75227243-3152-455c-9b17-aa74749fc5bb.png)

# Suggestion
- create a ticket to fix footer alignment