### PR TITLE
Feat/link glossary items to wikipedia page

### DIFF
--- a/frontend/client/src/Pages/Glossary/Glossary.jsx
+++ b/frontend/client/src/Pages/Glossary/Glossary.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from 'react';
 import {
   Search,
   Parent,
@@ -15,112 +15,18 @@ import {
   RightMiddle,
   RightBottom,
   Head,
-} from "./GlossaryElement";
+} from './GlossaryElement';
+import { boxes } from './GlossaryData';
 // test
 function Glossary() {
-  const boxes = [
-    {
-      name: "A",
-      items: ["Agent", "Appreciation", "Ask Rate", "Aa3"],
-    },
+  const [searchField, setSearchField] = useState('');
+  const filteredData = boxes.filter((item) => {
+    return item.name.toLowerCase().includes(searchField.toLowerCase());
+  });
 
-    {
-      name: "B",
-      items: ["Base Currency", "Bank Account", "Buy Rate", "Bank Fee"],
-    },
-
-    {
-      name: "C",
-      items: [
-        "Central Bank",
-
-        "Cheque",
-        "Comission",
-        "Commission",
-        "Credit Card",
-      ],
-    },
-
-    {
-      name: "D",
-      items: ["Debit card", "Deposit", "Delivary", "Dept"],
-    },
-
-    {
-      name: "E",
-      items: ["ECB", "EBT", "EBIT", "EPS"],
-    },
-
-    {
-      name: "F",
-      items: ["Fee", "FDI", "Fair Trade", "Foreign Exchange"],
-    },
-
-    {
-      name: "G",
-      items: ["Gold Standard", "GDP", "GNP", "GOP"],
-    },
-
-    {
-      name: "H",
-      items: ["Hot Money", "HSI", "Hard Currency", "Hard inquiry"],
-    },
-    {
-      name: "I",
-      items: ["Income", "Inflation", "Interest", "inventory"],
-    },
-    {
-      name: "J",
-      items: ["JV", "Jumbo CD", "Junk Bond", "Jit"],
-    },
-    {
-      name: "K",
-      items: ["KPI", "Kernel", "Key Currency", "Key Ring"],
-    },
-    {
-      name: "L",
-      items: ["Liquidity", "Lock-in", "Long Run", "Limit Order"],
-    },
-    {
-      name: "M",
-      items: ["MF", "Materials", "Market Risk", "Mortgage"],
-    },
-    {
-      name: "N",
-      items: ["Net Income", "Net Sale", "Net Worth", "NPA"],
-    },
-    {
-      name: "O",
-      items: ["Object Cost", "OEI", "OEM", "OAC"],
-    },
-    {
-      name: "P",
-      items: ["Premium", "Preferred Stock", "Policy Terms", "Profit"],
-    },
-    {
-      name: "Q",
-      items: ["QDRO", "Quote", "Quotation", "Qubes"],
-    },
-    {
-      name: "R",
-      items: ["Ratio", "RBI", "ROI", "Repo"],
-    },
-    {
-      name: "S",
-      items: ["Shares", "Sharp Ration", "Solvancy", "Sharesholder"],
-    },
-    {
-      name: "T",
-      items: ["Trust", "Turns", "Tick", "TAFR"],
-    },
-
-    { name: "U" },
-    { name: "V" },
-    { name: "W" },
-    { name: "X" },
-    { name: "Y" },
-    { name: "Z" },
-  ];
+  const handleChange = (e) => {
+    setSearchField(e.target.value);
+  };
 
   return (
     <>
@@ -131,48 +37,54 @@ function Glossary() {
         </Head>
         <Search>
           <div>
-            <img src="/assets/png/search.png" alt="" />
-          </div>{" "}
-          <input type="text" />
+            <img src='/assets/png/search.png' alt='' />
+          </div>{' '}
+          <input type='text' onChange={handleChange} />
         </Search>
 
         <ImageLeft>
           <LeftTop>
-            <img src="/assets/png/2 1.png" alt="" />
+            <img src='/assets/png/2 1.png' alt='' />
           </LeftTop>
           <LeftMiddle>
-            <img src="/assets/png/3 1.png" alt="" />
+            <img src='/assets/png/3 1.png' alt='' />
           </LeftMiddle>
           <LeftBottom>
-            <img src="/assets/png/4 1.png" alt="" />
+            <img src='/assets/png/4 1.png' alt='' />
           </LeftBottom>
         </ImageLeft>
 
         <ImageRight>
           <RightTop>
-            <img src="/assets/png/5 1.png" alt="" />
+            <img src='/assets/png/5 1.png' alt='' />
           </RightTop>
           <RightMiddle>
-            <img src="/assets/png/7 1.png" alt="" />
+            <img src='/assets/png/7 1.png' alt='' />
           </RightMiddle>
           <RightBottom>
-            <img src="/assets/png/8 1.png" alt="" />
+            <img src='/assets/png/8 1.png' alt='' />
           </RightBottom>
         </ImageRight>
       </Header>
       <Alphabet>
-        {boxes.map((b) =>
+        {filteredData.map((b) =>
           b?.items && b?.items?.length ? <h4>{b.name}</h4> : <h3>{b.name}</h3>
         )}
       </Alphabet>
       <Parent>
-        {boxes.map((b) =>
+        {filteredData.map((b) =>
           b?.items && b?.items?.length ? (
             <Box>
               <h4>{b.name}</h4>
               <Items>
                 {b.items.map((item) => {
-                  return <span>{item}</span>;
+                  return (
+                    <span>
+                      <a href={item.link} noreferrer target='blank'>
+                        {item.text}
+                      </a>
+                    </span>
+                  );
                 })}
               </Items>
             </Box>

--- a/frontend/client/src/Pages/Glossary/GlossaryData.js
+++ b/frontend/client/src/Pages/Glossary/GlossaryData.js
@@ -1,0 +1,373 @@
+export const boxes = [
+  {
+    name: 'A',
+    items: [
+      {
+        text: 'Agent',
+        link: 'https://en.wikipedia.org/wiki/Agent_(economics)',
+      },
+      {
+        text: 'Appreciation',
+        link: 'https://en.wikipedia.org/wiki/Currency_appreciation_and_depreciation',
+      },
+      {
+        text: 'Ask Rate',
+        link: 'https://en.wikipedia.org/wiki/Exchange_rate',
+      },
+      {
+        text: 'Aa3',
+        link: 'https://en.wikipedia.org/wiki/Moody%27s_Investors_Service',
+      },
+    ],
+  },
+
+  {
+    name: 'B',
+    items: [
+      {
+        text: 'Base Currency',
+        link: 'https://en.wikipedia.org/wiki/Currency_pair',
+      },
+      {
+        text: 'Bank Account',
+        link: 'https://en.wikipedia.org/wiki/Bank_account',
+      },
+      {
+        text: 'Buy Rate',
+        link: 'https://en.wikipedia.org/wiki/Exchange_rate',
+      },
+      { text: 'Bank Fee', link: 'https://en.wikipedia.org/wiki/Bank_charge' },
+    ],
+  },
+
+  {
+    name: 'C',
+    items: [
+      {
+        text: 'Central Bank',
+        link: 'https://en.wikipedia.org/wiki/Central_bank',
+      },
+      { text: 'Cheque', link: 'https://en.wikipedia.org/wiki/Cheque' },
+      {
+        text: 'Comission',
+        link: 'https://en.wikipedia.org/wiki/Commission_(remuneration)',
+      },
+      {
+        text: 'Credit Card',
+        link: 'https://en.wikipedia.org/wiki/Credit_card',
+      },
+    ],
+  },
+
+  {
+    name: 'D',
+    items: [
+      {
+        text: 'Debit card',
+        link: 'https://en.wikipedia.org/wiki/Debit_card',
+      },
+      {
+        text: 'Deposit',
+        link: 'https://en.wikipedia.org/wiki/Deposit_(finance)',
+      },
+      {
+        text: 'Delivary',
+        link: 'https://en.wikipedia.org/wiki/Delivery_(commerce)',
+      },
+      {
+        text: 'Dept',
+        link: 'https://en.wikipedia.org/wiki/Departmentalization',
+      },
+    ],
+  },
+
+  {
+    name: 'E',
+    items: [
+      {
+        text: 'ECB',
+        link: 'https://en.wikipedia.org/wiki/European_Central_Bank',
+      },
+      {
+        text: 'EBT',
+        link: 'https://en.wikipedia.org/wiki/Earnings_before_interest_and_taxes',
+      },
+      {
+        text: 'EBIT',
+        link: 'https://en.wikipedia.org/wiki/Earnings_before_interest_and_taxes',
+      },
+      {
+        text: 'EPS',
+        link: 'https://en.wikipedia.org/wiki/Earnings_per_share',
+      },
+    ],
+  },
+
+  {
+    name: 'F',
+    items: [
+      { text: 'Fee', link: 'https://en.wikipedia.org/wiki/Bank_charge' },
+      {
+        text: 'FDI',
+        link: 'https://en.wikipedia.org/wiki/Foreign_direct_investment',
+      },
+      {
+        text: 'Fair Trade',
+        link: 'https://en.wikipedia.org/wiki/Fair_trade',
+      },
+      {
+        text: 'Foreign Exchange',
+        link: 'https://en.wikipedia.org/wiki/Foreign_exchange_market',
+      },
+    ],
+  },
+
+  {
+    name: 'G',
+    items: [
+      {
+        text: 'Gold Standard',
+        link: 'https://en.wikipedia.org/wiki/Gold_standard',
+      },
+      {
+        text: 'GDP',
+        link: 'https://en.wikipedia.org/wiki/Gross_domestic_product',
+      },
+      {
+        text: 'GNP',
+        link: 'https://en.wikipedia.org/wiki/Gross_national_income',
+      },
+      {
+        text: 'GOP',
+        link: 'https://en.wikipedia.org/wiki/Republican_Party_(United_States)',
+      },
+    ],
+  },
+
+  {
+    name: 'H',
+    items: [
+      { text: 'Hot Money', link: 'https://en.wikipedia.org/wiki/Hot_money' },
+      { text: 'HSI', link: 'https://en.wikipedia.org/wiki/Hang_Seng_Index' },
+      {
+        text: 'Hard Currency',
+        link: 'https://en.wikipedia.org/wiki/Hard_currencyt',
+      },
+      {
+        text: 'Hard inquiry',
+        link: 'https://www.investopedia.com/terms/h/hard-inquiry.asp',
+      },
+    ],
+  },
+  {
+    name: 'I',
+    items: [
+      { text: 'Income', link: 'https://en.wikipedia.org/wiki/Income' },
+      { text: 'Inflation', link: 'https://en.wikipedia.org/wiki/Inflation' },
+      { text: 'Interest', link: 'https://en.wikipedia.org/wiki/Interest' },
+      { text: 'inventory', link: 'https://en.wikipedia.org/wiki/Inventory' },
+    ],
+  },
+  {
+    name: 'J',
+    items: [
+      { text: 'JV', link: 'https://en.wikipedia.org/wiki/Joint_venture' },
+      {
+        text: 'Jumbo CD',
+        link: 'https://en.wikipedia.org/wiki/Certificate_of_deposit',
+      },
+      {
+        text: 'Junk Bond',
+        link: 'https://en.wikipedia.org/wiki/High-yield_debt',
+      },
+      {
+        text: 'Jit',
+        link: 'https://en.wikipedia.org/wiki/Just-in-time_compilation',
+      },
+    ],
+  },
+  {
+    name: 'K',
+    items: [
+      {
+        text: 'KPI',
+        link: 'https://en.wikipedia.org/wiki/Performance_indicator',
+      },
+      {
+        text: 'Kernel',
+        link: 'https://en.wikipedia.org/wiki/Kernel_(algebra)',
+      },
+      {
+        text: 'Key Currency',
+        link: 'https://en.wikipedia.org/wiki/Exchange_rate',
+      },
+      { text: 'Key Ring', link: '' },
+    ],
+  },
+  {
+    name: 'L',
+    items: [
+      {
+        text: 'Liquidity',
+        link: 'https://en.wikipedia.org/wiki/Market_liquidity',
+      },
+      { text: 'Lock-in', link: 'https://en.wiktionary.org/wiki/lock-in' },
+      {
+        text: 'Long Run',
+        link: 'https://en.wikipedia.org/wiki/Long_run_and_short_run',
+      },
+      {
+        text: 'Limit Order',
+        link: 'https://en.wikipedia.org/wiki/Order_(exchange)#Limit_order',
+      },
+    ],
+  },
+  {
+    name: 'M',
+    items: [
+      { text: 'MF', link: 'https://en.wikipedia.org/wiki/Mutual_fund' },
+      { text: 'Materials', link: 'https://en.wikipedia.org/wiki/Material' },
+      {
+        text: 'Market Risk',
+        link: 'https://en.wikipedia.org/wiki/Market_risk',
+      },
+      {
+        text: 'Mortgage',
+        link: 'https://en.wikipedia.org/wiki/Mortgage_loan',
+      },
+    ],
+  },
+  {
+    name: 'N',
+    items: [
+      {
+        text: 'Net Income',
+        link: 'https://en.wikipedia.org/wiki/Net_income',
+      },
+      { text: 'Net Sale', link: 'https://en.wikipedia.org/wiki/Revenue' },
+      { text: 'Net Worth', link: 'https://en.wikipedia.org/wiki/Net_worth' },
+      {
+        text: 'NPA',
+        link: 'https://en.wikipedia.org/wiki/Non-performing_loan',
+      },
+    ],
+  },
+  {
+    name: 'O',
+    items: [
+      {
+        text: 'Object Cost',
+        link: 'https://en.wikipedia.org/wiki/Cost_object',
+      },
+      {
+        text: 'OEI',
+        link: 'https://en.wikipedia.org/wiki/Organization_of_Ibero-American_States',
+      },
+      {
+        text: 'OEM',
+        link: 'https://en.wikipedia.org/wiki/Original_equipment_manufacturer#Economies_of_scale',
+      },
+      {
+        text: 'OAC',
+        link: 'https://en.wikipedia.org/wiki/Object_Action_Complex',
+      },
+    ],
+  },
+  {
+    name: 'P',
+    items: [
+      { text: 'Premium', link: 'https://en.wikipedia.org/wiki/Risk_premium' },
+      {
+        text: 'Preferred Stock',
+        link: 'https://en.wikipedia.org/wiki/Preferred_stock',
+      },
+      { text: 'Policy Terms', link: 'https://en.wikipedia.org/wiki/Policy' },
+      {
+        text: 'Profit',
+        link: 'https://en.wikipedia.org/wiki/Profit_(economics)',
+      },
+    ],
+  },
+  {
+    name: 'Q',
+    items: [
+      {
+        text: 'QDRO',
+        link: 'https://en.wikipedia.org/wiki/Qualified_domestic_relations_order',
+      },
+      {
+        text: 'Quote',
+        link: 'https://en.wikipedia.org/wiki/Agent',
+      },
+      { text: 'Quotation', link: 'https://en.wikipedia.org/wiki/Quotation' },
+      {
+        text: 'Qubes',
+        link: 'https://financial-dictionary.thefreedictionary.com/Qubes',
+      },
+    ],
+  },
+  {
+    name: 'R',
+    items: [
+      { text: 'Ratio', link: 'https://en.wikipedia.org/wiki/Ratio' },
+      {
+        text: 'RBI',
+        link: 'https://en.wikipedia.org/wiki/Reserve_Bank_of_India',
+      },
+      {
+        text: 'ROI',
+        link: 'https://en.wikipedia.org/wiki/Return_on_investment',
+      },
+      {
+        text: 'Repo',
+        link: 'https://en.wikipedia.org/wiki/Repurchase_agreement',
+      },
+    ],
+  },
+  {
+    name: 'S',
+    items: [
+      {
+        text: 'Shares',
+        link: 'https://en.wikipedia.org/wiki/Share_(finance)',
+      },
+      {
+        text: 'Sharp Ration',
+        link: 'https://fsinvestments.com/fs-insights/chart-of-the-week-2022-1-14-value-growth-returns/',
+      },
+      {
+        text: 'Solvancy',
+        link: 'https://www.investopedia.com/terms/s/solvency.asp',
+      },
+      {
+        text: 'Sharesholder',
+        link: 'https://en.wikipedia.org/wiki/Shareholder',
+      },
+    ],
+  },
+  {
+    name: 'T',
+    items: [
+      {
+        text: 'Trust',
+        link: 'https://en.wikipedia.org/wiki/Trust_(business)',
+      },
+      {
+        text: 'Turns',
+        link: 'https://en.wikipedia.org/wiki/Inventory_turnover',
+      },
+      {
+        text: 'Tick',
+        link: 'https://www.investopedia.com/terms/t/tick.asp#:~:text=A%20tick%20is%20a%20measure,above%20%241%20is%20one%20cent.',
+      },
+      { text: 'TAFR', link: 'https://en.wikipedia.org/wiki/Trust-fund_tax' },
+    ],
+  },
+
+  { name: 'U' },
+  { name: 'V' },
+  { name: 'W' },
+  { name: 'X' },
+  { name: 'Y' },
+  { name: 'Z' },
+];

--- a/frontend/client/src/Pages/Glossary/GlossaryElement.jsx
+++ b/frontend/client/src/Pages/Glossary/GlossaryElement.jsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled from 'styled-components';
 
 export const Alphabet = styled.div`
   box-sizing: border-box;
@@ -92,7 +92,7 @@ export const Head = styled.div`
     }
   }
 
-  @media screen and (max-width: 375px) {
+  @media screen and (max-width: 768px) {
     h1 {
       font-size: 28px;
       line-height: 32px;
@@ -149,7 +149,7 @@ export const Search = styled.div`
     }
   }
 
-  @media screen and (max-width: 375px) {
+  @media screen and (max-width: 768px) {
     max-width: 253px;
     height: 27px;
 
@@ -165,20 +165,19 @@ export const Search = styled.div`
 export const Parent = styled.div`
   box-sizing: border-box;
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr;
-
+  grid-template-columns: 1fr 1fr 1fr;
+  padding: 50px 17px;
   width: 100%;
   max-width: 1440px;
   margin: 0 auto;
-  padding: 17px 120px;
 
-  @media screen and (max-width: 834px) {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
+  @media only screen and (min-width: 768px) {
     padding: 50px 80px;
   }
-  @media screen and (max-width: 375px) {
-    padding: 50px 17px;
+
+  @media only screen and (min-width: 992px) {
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+    padding: 17px 120px;
   }
 `;
 
@@ -192,7 +191,7 @@ export const Box = styled.div`
     font-size: 28px;
     line-height: 32px;
     font-weight: 700;
-    font-family: "Inter";
+    font-family: 'Inter';
     border-bottom: 1px solid #94a3b8;
     padding-bottom: 18px;
     padding-top: 18px;
@@ -210,7 +209,7 @@ export const Box = styled.div`
       line-height: 24px;
     }
   }
-  @media screen and (max-width: 375px) {
+  @media screen and (max-width: 768px) {
     min-width: 90px;
     max-width: 90px;
 
@@ -230,29 +229,24 @@ export const Items = styled.div`
   flex-direction: column;
   margin-top: 20px;
 
-  span {
-    font-family: "Inter";
-    font-weight: 600;
+  span a {
+    font-family: 'Inter';
+    font-weight: 500;
     font-size: 20px;
-    line-height: 28px;
+    line-height: 4.5rem;
     color: #475569;
     margin-bottom: 20px;
   }
 
-  span {
-    font-size: 16px;
-    line-height: 24px;
-  }
-
   @media screen and (max-width: 834px) {
-    span {
+    span a {
       font-size: 16px;
       line-height: 24px;
     }
   }
 
-  @media screen and (max-width: 375px) {
-    span {
+  @media screen and (max-width: 768px) {
+    span a {
       font-size: 12px;
       line-height: 18px;
     }
@@ -289,7 +283,7 @@ export const ImageLeft = styled.div`
   @media screen and (max-width: 834px) {
     left: 30px;
   }
-  @media screen and (max-width: 375px) {
+  @media screen and (max-width: 768px) {
     left: 10px;
   }
 `;
@@ -315,7 +309,7 @@ export const ImageRight = styled.div`
       object-fit: contain;
     }
   }
-  @media screen and (max-width: 375px) {
+  @media screen and (max-width: 768px) {
     right: 10px;
     img {
       width: 30px;


### PR DESCRIPTION
STR-23:Link Glossary items to Wikipedia page
https://linear.app/team-bevel/issue/STR-23/link-glossary-items-to-wikipedia-page.
- I linked the glossary items to a Wikipedia page.
 

https://user-images.githubusercontent.com/29485257/204812602-fda55ddd-7ffd-46c2-8789-a206e6b78ca5.mp4

