### PR TITLE
BAC-30: Create endpoint to return currency, rates and country flags

### DIFF
--- a/backend/app/api/v1/currency.py
+++ b/backend/app/api/v1/currency.py
@@ -5,6 +5,8 @@ from sqlalchemy.orm import Session
 
 from app import schemas, crud
 from app.api.deps import get_db
+from app.models.rate import Rate
+import requests
 
 router = APIRouter()
 
@@ -31,3 +33,38 @@ def get_all_currencies(db: Session = Depends(get_db)):
     }
 
     return data
+
+@router.get("/currencies/{isocode}")
+def get_currencies_and_rates(isocode: str, db: Session = Depends(get_db)):
+    """
+    gets the rates of all currencies in respect to a base currency
+    also gets the country flags.
+    """
+    # Get currency
+    currency = crud.currency.get_currency_by_isocode(db, isocode.upper())
+
+    # Get other currencies
+    all_currencies = crud.currency.get_currencies_and_rate(db, isocode.upper())
+
+    # Get country codes
+    codes = requests.get("https://flagcdn.com/en/codes.json").json()
+    
+    # Create object
+    currencies = []
+    
+    for cur in all_currencies:
+        currency = cur.dict()
+        rate = db.query(Rate).filter(
+            Rate.currency_id == cur.id
+            ).order_by(Rate.id.desc()).first()
+        currency["rate"] = rate
+        # Get currency flag
+        name = cur.country
+        for key, value in codes.items():
+            if value == name:
+                currency["flag"] = f"https://flagcdn.com/{key}.svg"
+                break
+
+        currencies.append(currency)
+
+    return currencies

--- a/backend/app/crud/currency.py
+++ b/backend/app/crud/currency.py
@@ -37,6 +37,11 @@ class CRUDCurrency(CRUDBase[Currency, CurrencyCreate, CurrencyUpdate]):
         db.commit()
 
         return currency
+    
+    def get_currencies_and_rate(self, db: Session, isocode: str):
+        """Returns all currencies minus the base currency"""
+        currencies = db.query(Currency).filter(Currency.isocode != isocode).all()
+        return currencies
 
 
 currency = CRUDCurrency(Currency)

--- a/backend/app/models/currency.py
+++ b/backend/app/models/currency.py
@@ -14,3 +14,13 @@ class Currency(Base):
 
     rates = relationship(
         "Rate", back_populates="currency", cascade="all, delete")
+
+    def dict(self):
+        """Returns dictionary representation of currency"""
+        dict = {}
+        dict["id"] = self.id
+        dict["country"] = self.country
+        dict["isocode"] = self.isocode
+        dict["symbol"] = self.symbol
+
+        return dict


### PR DESCRIPTION
The endpoint receives the isocode of the base currency and returns all other currencies in the database, including their rates and country flags.

Example response:

```
[
  {
    "id": 2,
    "country": "Ghana",
    "isocode": "GHS",
    "symbol": "₵",
    "rate": {
      "id": 24,
      "parallel_buy": 14.79,
      "last_updated": "2022-11-26T15:28:27.554471",
      "official_buy": 14.503954,
      "official_sell": 14.503954,
      "parallel_sell": 14.78,
      "currency_id": 2
    },
    "flag": "https://flagcdn.com/gh.svg"
  }
]
```