### PR TITLE
feat-BAC-23-an-endpoint-that-return-the-last-time-and-date-the-rates-were-updated

### DIFF
--- a/backend/app/api/v1/rate.py
+++ b/backend/app/api/v1/rate.py
@@ -228,3 +228,16 @@ def get_highest_and_lowest_rates(isocode, db: Session = Depends(get_db)):
         "status_code": 200,
         "data": {"currency": currency, "rates": result},
     }
+
+
+
+@router.put("/last_rate_update")
+def last_rate_update(db: Session = Depends(get_db)):
+    """
+    returns the last date and time the currency rates where updated
+    """
+    time = db.query(Rate).order_by(Rate.last_updated.desc()).first().last_updated
+    return{
+        "Success": True,
+        "Time": time
+    }


### PR DESCRIPTION


linear : BAC-23 (https://linear.app/team-bevel/issue/BAC-23/create-an-endpoint-that-return-the-last-time-and-date-the-rates-were)

An endpoint that returns the date and time the rates in the database were updated.

