### PR TITLE
hotfix: fixed the endpoint to get rates from external apis

### DIFF
--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional
 import aiohttp
 import requests
 from app import crud
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import Depends
 from app.api.deps import get_db
 from sqlalchemy.orm import Session
 from app.schemas import BinanceRequestSchema, BinanaceResponseSchema
@@ -65,9 +65,8 @@ async def format_binance_response_data(response_data: List[Dict[str, Any]]) -> A
     return {"buy_rate": buy_rate, "sell_rate": sell_rate}
 
 
-def make_official_rate_request(base_currency: str, currency_list: List[str]) -> Any:
-    currencies = ','.join(currency_list)
-    url = f"{official_rate_endpoint}?base={base_currency}&symbols={currencies}"
+async def make_official_rate_request(base_currency: str) -> Any:
+    url = f"{official_rate_endpoint}?base={base_currency}"
     response = requests.get(url)
     data = response.json()
     return data


### PR DESCRIPTION
Ticket: [BAC-54](https://linear.app/team-bevel/issue/BAC-54/fix-the-endpoint-that-helps-us-to-populate-our-database-with-the-rates)

- Fixed the /services/rates endpoint to update rates in the database
- Improved the official rates request to get all the rates in one request thereby reducing the time taken to update rates significantly
- Formatted the code

**How it works**
Endpoint: `GET`: `https://api.streetrates.hng.tech/services/rates`
The endpoint is attached to a cron-job service to run every 5 mins to update our database with new rates
