### PR TITLE
Affiliate

### DIFF
--- a/frontend/client/src/Pages/PartnersForm/AffiliatePartners/database.js
+++ b/frontend/client/src/Pages/PartnersForm/AffiliatePartners/database.js
@@ -18,9 +18,9 @@ const app = initializeApp(firebaseConfig);
 // export dp instance
 const db = getFirestore(app);
 
-export const addAffiliate = async (data) => {
+export const addPartner = async (table, data) => {
   try {
-    const docRef = await addDoc(collection(db, "affiliate"), data);
+    const docRef = await addDoc(collection(db, table), data);
     return "Document written with ID: " + docRef.id;
   } catch (e) {
     return "Error adding document: " + e;


### PR DESCRIPTION
changed addAffiliate function to AddPartner
it can now take two arguments. one is the table name  in cloud firestore and the other is the data
` addPartner("referral", data) `   or `    addPartner("affiliate", data)`
